### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -119,7 +119,8 @@
           "POST",
           "PATCH"
         ],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {}
       },
       {
         "url": "https://app.copper.com/oauth/.*",
@@ -129,7 +130,15 @@
           "POST",
           "PATCH"
         ],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "client_id": {
+            "body": ["client_id"]
+          },
+          "client_secret": {
+            "body": ["client_secret"]
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This pull request updates the `manifest.json` file to support injecting sensitive configuration values into requests for OAuth integration. The main focus is on adding a `settingsInjection` field to relevant endpoints, which allows the system to automatically include the `client_id` and `client_secret` in the request body, improving flexibility and security in handling authentication.

Enhancements to OAuth endpoint configuration:

* Added a `settingsInjection` field to the OAuth endpoint configuration, enabling automatic injection of settings such as `client_id` and `client_secret` into the request body.
* Introduced an empty `settingsInjection` object to another endpoint, preparing it for future configuration injection support.